### PR TITLE
Update diskuv.gitlab.io links to diskuv-ocaml.gitlab.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,14 @@ Briefly review the following:
 Then run the [latest Windows 64-bit installer](https://github.com/diskuv/dkml-installer-ocaml/releases/download/v1.1.0/setup-diskuv-ocaml-windows_x86_64-1.1.0.exe).
 
 Now that your install is completed, you can read the
-[Install is done! What next?](https://diskuv.gitlab.io/diskuv-ocaml/#install-is-done-what-next)
+[Install is done! What next?](https://diskuv-ocaml.gitlab.io/distributions/dkml/#install-is-done-what-next)
 documentation.
 
 ---
 
 The full set of releases is at https://github.com/diskuv/dkml-installer-ocaml/releases
 
-The full documentation is at https://diskuv.gitlab.io/diskuv-ocaml/#introduction
+The full documentation is at https://diskuv-ocaml.gitlab.io/distributions/dkml/#introduction
 
 ## Sponsor
 

--- a/installer/src/private_common.ml
+++ b/installer/src/private_common.ml
@@ -32,7 +32,7 @@ let program_info =
       Some "https://github.com/diskuv/dkml-installer-ocaml#readme";
     url_update_info_opt =
       Some "https://gitlab.com/diskuv/diskuv-ocaml/-/blob/main/CHANGES.md";
-    help_link_opt = Some "https://diskuv.gitlab.io/diskuv-ocaml/#introduction";
+    help_link_opt = Some "https://diskuv-ocaml.gitlab.io/distributions/dkml/#introduction";
     (*
         1698886537L bytes (1.6 GB) in DKML 1.1.0
       - "{0} B" -f (Get-ChildItem $env:DiskuvOCamlHome -Recurse | Measure-Object -Property Length -Sum -ErrorAction Stop).Sum

--- a/vagrant/win32/test-language.ps1
+++ b/vagrant/win32/test-language.ps1
@@ -29,7 +29,7 @@ Set-Content `
   -Value "((trust_anchors (`"$EscapedHereDir\\mock-ca-cert.pem`")))"
 
 # ========================
-# START Install instructions from https://diskuv.gitlab.io/diskuv-ocaml/index.html
+# START Install instructions from https://diskuv-ocaml.gitlab.io/distributions/dkml/index.html
 
 #   --ci will skip confirmation question at end of setup.exe
 $opts = "--ci"


### PR DESCRIPTION
This removes the extra link redirections.